### PR TITLE
Update gptsync.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ gptsync
 Here's an OSX port and enhancement i made to help creating hybrid MBR partitions on GPT drive.
 
 Code came from project rEFit: http://refit.sourceforge.net/
+
+Usage: gptsync [OPTION]... DEVICE [PARTITION[+/-[TYPE]]] ...
+
+gptsync fill hybrid MBR of GPT drive DEVICE.
+
+Specified partitions will be a part of hybrid MBR. Up to 3 partitions are allowed.
++ means that partition is active (only one partition can be active).
+TYPE is an MBR hexadecimal type (use -t option to list recognized types).
+
+Valid options:
+  -e, --empty             create an MBR containing only the EFI Protective partition
+  -n, --nofill            don't try to protect unused partition
+  -t, --types             list the MBR recognized type codes
+  -h, --help              display this message and exit
+  -V, --version           print version information and exit

--- a/README.md
+++ b/README.md
@@ -5,17 +5,25 @@ Here's an OSX port and enhancement i made to help creating hybrid MBR partitions
 
 Code came from project rEFit: http://refit.sourceforge.net/
 
-Usage: gptsync [OPTION]... DEVICE [PARTITION[+/-[TYPE]]] ...
+Usage: 
+```
+gptsync [OPTION]... DEVICE [PARTITION[+/-[TYPE]]] ...
+```
 
 gptsync fill hybrid MBR of GPT drive DEVICE.
 
 Specified partitions will be a part of hybrid MBR. Up to 3 partitions are allowed.
-+ means that partition is active (only one partition can be active).
-TYPE is an MBR hexadecimal type (use -t option to list recognized types).
+`+` means that partition is active (only one partition can be active).
+TYPE is an MBR hexadecimal type (use `-t` option to list recognized types).
 
 Valid options:
-  -e, --empty             create an MBR containing only the EFI Protective partition
-  -n, --nofill            don't try to protect unused partition
-  -t, --types             list the MBR recognized type codes
-  -h, --help              display this message and exit
-  -V, --version           print version information and exit
+
+  `-e, --empty`             create an MBR containing only the EFI Protective partition
+  
+  `-n, --nofill`            don't try to protect unused partition
+  
+  `-t, --types`             list the MBR recognized type codes
+  
+  `-h, --help`              display this message and exit
+  
+  `-V, --version`           print version information and exit

--- a/gptsync.c
+++ b/gptsync.c
@@ -51,7 +51,7 @@
 int xtoi(const char* xs, UINT8* result)
 {
 	size_t szlen = strlen(xs);
-	int i, xv, fact;
+	int xv, fact;
 	
 	if (szlen > 0)
 	{

--- a/gptsync.c
+++ b/gptsync.c
@@ -63,7 +63,7 @@ int xtoi(const char* xs, UINT8* result)
 		fact = 1;
 		
 		// Run until no more character to convert
-		for(i=szlen-1; i>=0 ;i--)
+		for(size_t i = szlen - 1; i != (size_t)-1; i--)
 		{
 			if (isxdigit(*(xs+i)))
 			{


### PR DESCRIPTION
The loop variable `i `is of type `int`, and it’s being compared to `szlen`, which is of type `size_t`. The `size_t` type is an unsigned type, and on some platforms, it can be larger than an `int`. This mismatch can cause potential issues if `szlen` is larger than the maximum value an `int` can hold.